### PR TITLE
Older BUSCO uses "number of species".

### DIFF
--- a/make_EAR.py
+++ b/make_EAR.py
@@ -413,7 +413,11 @@ def make_report(yaml_file):
                 if lineage_info:
                     return lineage_info.groups()
                 else:
-                    return None
+                    lineage_info = re.search(r"The lineage dataset is: (.*?) \(Creation date:.*?, number of species: (\d+), number of BUSCOs: (\d+)\)", content)
+                    if lineage_info:
+                        return lineage_info.groups()
+                    else:
+                        return None
         except Exception as e:
             logging.warning(f"Error reading {file_path}: {str(e)}")
             return None


### PR DESCRIPTION
I could not get `make_EAR.py` to run and realized it brakes because my input BUSCO short summaries use the wording "The lineage dataset is: blabla. Creation date: date1, number of **species**: xy, number of BUSCOs: xz" instead of **genomes** . I used quast, that uses an older BUSCO version (3.0.2).