### PR TITLE
exclude the 'erga-ear-bot[bot]' actor from running the workflow

### DIFF
--- a/.github/workflows/2+4_ear_bot_comment.yml
+++ b/.github/workflows/2+4_ear_bot_comment.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   new-comment:
-    if: github.event.issue.pull_request && (contains(github.event.issue.labels.*.name, 'ERGA-BGE') || contains(github.event.issue.labels.*.name, 'ERGA-Pilot') || contains(github.event.issue.labels.*.name, 'ERGA-Community'))
+    if: github.actor != 'erga-ear-bot[bot]' && github.event.issue.pull_request && (contains(github.event.issue.labels.*.name, 'ERGA-BGE') || contains(github.event.issue.labels.*.name, 'ERGA-Pilot') || contains(github.event.issue.labels.*.name, 'ERGA-Community'))
     runs-on: ubuntu-latest
     steps:
       - name: Generate a token


### PR DESCRIPTION
This is an update for https://github.com/ERGA-consortium/EARs/pull/54