### PR TITLE
Update EAR bot

### DIFF
--- a/.github/workflows/1_ear_bot_pr.yml
+++ b/.github/workflows/1_ear_bot_pr.yml
@@ -2,7 +2,7 @@ name: The EARs Reviewing bot for PRs
 
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, edited]
     paths:
       - "Assembly_Reports/**/*.pdf"
 
@@ -40,4 +40,5 @@ jobs:
           GITHUB_APP_TOKEN: ${{ steps.generate-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          ACTION_TYPE: ${{ github.event.action }}
         run: python -u ear_bot/ear_bot_reviewer.py --supervisor


### PR DESCRIPTION
This is an update for #54

- Handle the 'edited' event type to re-run the job on each pr body change if there was an error label
- Added validation for the number of changed files in pull requests and provided feedback to the user if more than one file is changed
- Removed the 'ERROR!' label if it existed in the pull request after successful validation
- Prevent duplicate comments