### PR TITLE
Add ping reminder for inactive PRs

### DIFF
--- a/ear_bot/ear_bot_reviewer.py
+++ b/ear_bot/ear_bot_reviewer.py
@@ -207,7 +207,7 @@ class EARBotReviewer:
 
         for pr in prs:
             if pr.updated_at.astimezone(cet) + timedelta(days=7) < current_date:
-                supervisor = pr.assignee.login
+                supervisor = pr.assignee.login if pr.assignee else pr.user.login
                 pr.create_issue_comment(
                     f"Ping @{supervisor},\nOne week without any movements on this PR!"
                 )

--- a/ear_bot/ear_bot_reviewer.py
+++ b/ear_bot/ear_bot_reviewer.py
@@ -206,6 +206,11 @@ class EARBotReviewer:
         current_date = datetime.now(tz=cet)
 
         for pr in prs:
+            if pr.updated_at.astimezone(cet) + timedelta(days=7) < current_date:
+                supervisor = pr.assignee.login
+                pr.create_issue_comment(
+                    f"Ping @{supervisor},\nOne week without any movements on this PR!"
+                )
             if (
                 pr.get_review_requests()[0].totalCount > 0
                 or not any(


### PR DESCRIPTION
This is an update for #54
This pull request adds a feature to send a ping reminder to the assigned supervisor of a pull request if there has been no activity on the PR for one week.