### PR TITLE
Use Slack for creating a post

### DIFF
--- a/.github/workflows/6_ear_bot_merge.yml
+++ b/.github/workflows/6_ear_bot_merge.yml
@@ -34,6 +34,8 @@ jobs:
           GITHUB_APP_TOKEN: ${{ steps.generate-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+          SLACK_CHANNEL_ID: "C070UHJ80Q3"
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r ear_bot/requirements.txt

--- a/ear_bot/requirements.txt
+++ b/ear_bot/requirements.txt
@@ -1,2 +1,3 @@
 PyGithub
 pytz
+slack_sdk


### PR DESCRIPTION
This is an update for https://github.com/ERGA-consortium/EARs/pull/54
This pull request adds functionality to use Slack for creating a post. It includes changes to the code to integrate with the Slack API and send a message to a specific channel ([#wp9-assembly-delivery](https://biogeneu.slack.com/archives/C070UHJ80Q3)) when the EAR PR has been merged.
`SLACK_TOKEN` should be added to [github action secrets](https://github.com/ERGA-consortium/EARs/settings/secrets/actions/new) before merging this PR.