### PR TITLE
Add PDF to YAML support for EAR bot

### DIFF
--- a/.github/workflows/6_ear_bot_merge.yml
+++ b/.github/workflows/6_ear_bot_merge.yml
@@ -46,3 +46,9 @@ jobs:
         with:
           file_pattern: "rev/*.csv"
           branch: main
+
+      - name: Upload yaml file
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          file_pattern: "*.yaml"
+          branch: main

--- a/ear_bot/requirements.txt
+++ b/ear_bot/requirements.txt
@@ -1,3 +1,5 @@
 PyGithub
 pytz
 slack_sdk
+pdfplumber
+pyyaml


### PR DESCRIPTION
This is an update for #54

- Add pdfplumber and pyyaml to requirements.txt

- Format EARpdf_to_yaml.py file for better readability, update version and refactor to use absolute paths for saving yaml file

- Refactor EARBot to convert PDF file into yaml

- Upload created yaml file