### PR TITLE
Update slack post generation and disable globbing for YAML file pattern for EAR bot

### DIFF
--- a/.github/workflows/6_ear_bot_merge.yml
+++ b/.github/workflows/6_ear_bot_merge.yml
@@ -52,3 +52,4 @@ jobs:
         with:
           file_pattern: "*.yaml"
           branch: main
+          disable_globbing: true

--- a/ear_bot/ear_bot_reviewer.py
+++ b/ear_bot/ear_bot_reviewer.py
@@ -404,8 +404,16 @@ class EARBotReviewer:
                 institution=institution,
                 submitted_at=submitted_at,
             )
-            researcher_name = pr.user.name
-            supervisor_name = pr.assignee.name
+            researcher_name = next(
+                entry.get("Full Name", pr.user.name or pr.user.login)
+                for entry in self.EAR_reviewer.data
+                if entry.get("Github ID", "").lower() == pr.user.login
+            )
+            supervisor_name = next(
+                entry.get("Full Name", pr.assignee.name or pr.assignee.login)
+                for entry in self.EAR_reviewer.data
+                if entry.get("Github ID", "").lower() == pr.assignee.login
+            )
             EAR_pdf = next(
                 file
                 for file in pr.get_files()


### PR DESCRIPTION
This is an update for #54
This pull request includes two commits. The first commit updates the generation of slack posts by using the name from the reviewer CSV file. The second commit disables globbing for the YAML file pattern, that is needed to grab sub-folder YAML file changes.