### PR TITLE
Update cron schedule for EAR bot workflow

### DIFF
--- a/.github/workflows/3_ear_bot_reviewer.yml
+++ b/.github/workflows/3_ear_bot_reviewer.yml
@@ -2,7 +2,7 @@ name: The EARs Reviewing bot for assigning reviewer after supervisor approval
 
 on:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 9,21 * * *"
 
   workflow_dispatch:
 


### PR DESCRIPTION
This is an update for #54
Change the cron schedule to run the EAR bot reviewer workflow twice daily at 9 AM and 9 PM.
