### PR TITLE
Refactor commit steps into a function in ear bot Python file

### DIFF
--- a/.github/workflows/2+4_ear_bot_comment.yml
+++ b/.github/workflows/2+4_ear_bot_comment.yml
@@ -41,9 +41,3 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r ear_bot/requirements.txt
           python -u ear_bot/ear_bot_reviewer.py --comment
-
-      - name: Upload csv file
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          file_pattern: "rev/*.csv"
-          branch: main

--- a/.github/workflows/3_ear_bot_reviewer.yml
+++ b/.github/workflows/3_ear_bot_reviewer.yml
@@ -41,9 +41,3 @@ jobs:
           GITHUB_APP_TOKEN: ${{ steps.generate-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: python -u ear_bot/ear_bot_reviewer.py --search
-
-      - name: Upload csv file
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          file_pattern: "rev/*.csv"
-          branch: main

--- a/.github/workflows/5_ear_bot_approved_comment.yml
+++ b/.github/workflows/5_ear_bot_approved_comment.yml
@@ -85,9 +85,3 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r ear_bot/requirements.txt
           python -u ear_bot/ear_bot_reviewer.py --approve
-
-      - name: Upload csv file
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          file_pattern: "rev/*.csv"
-          branch: main

--- a/.github/workflows/6_ear_bot_merge.yml
+++ b/.github/workflows/6_ear_bot_merge.yml
@@ -42,16 +42,3 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r ear_bot/requirements.txt
           python -u ear_bot/ear_bot_reviewer.py --merge
-
-      - name: Upload csv file
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          file_pattern: "rev/*.csv"
-          branch: main
-
-      - name: Upload yaml file
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          file_pattern: "*.yaml"
-          branch: main
-          disable_globbing: true


### PR DESCRIPTION
This is an update for #54
Move the logic for committing files from GitHub Actions workflows into a dedicated function within the ear bot Python file.
This has been done as it wasn't possible anymore to do this when `persist-credentials: false` has been added to github action workflows.