### PR TITLE
Add serialize-workflow-action to manage concurrent workflows

### DIFF
--- a/.github/workflows/1_ear_bot_pr.yml
+++ b/.github/workflows/1_ear_bot_pr.yml
@@ -19,6 +19,10 @@ jobs:
           owner: "ERGA-consortium"
           repositories: "EARs"
 
+      - uses: jsok/serialize-workflow-action@v1
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/2+4_ear_bot_comment.yml
+++ b/.github/workflows/2+4_ear_bot_comment.yml
@@ -18,6 +18,10 @@ jobs:
           owner: "ERGA-consortium"
           repositories: "EARs"
 
+      - uses: jsok/serialize-workflow-action@v1
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+  
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/3_ear_bot_reviewer.yml
+++ b/.github/workflows/3_ear_bot_reviewer.yml
@@ -19,6 +19,10 @@ jobs:
           owner: "ERGA-consortium"
           repositories: "EARs"
 
+      - uses: jsok/serialize-workflow-action@v1
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+  
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/5_ear_bot_approved.yml
+++ b/.github/workflows/5_ear_bot_approved.yml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: jsok/serialize-workflow-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/6_ear_bot_merge.yml
+++ b/.github/workflows/6_ear_bot_merge.yml
@@ -18,6 +18,10 @@ jobs:
           owner: "ERGA-consortium"
           repositories: "EARs"
 
+      - uses: jsok/serialize-workflow-action@v1
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This is an update for https://github.com/ERGA-consortium/EARs/pull/54
Introduce the [serialize-workflow-action](https://github.com/marketplace/actions/serialize-workflow-runs) to ensure that workflows do not run concurrently, improving the stability of the CI/CD process.