### PR TITLE
Refactor EARBotReviewer to handle merged but unreviewed reports

### DIFF
--- a/ear_bot/ear_bot_reviewer.py
+++ b/ear_bot/ear_bot_reviewer.py
@@ -480,7 +480,9 @@ class EARBotReviewer:
             )
             self._add_yaml_file(EAR_pdf_filename)
             print("No review has been found for this merged PR.")
-            print("The YAML file has been added to the repository.")
+            pr.create_issue_comment(
+                "The YAML file has been updated based on the new EAR.pdf"
+            )
 
     def _search_comment_user(self, pr, text_to_check):
         comment_user = []


### PR DESCRIPTION
This is an update for #54
Enhance the EARBotReviewer to support the addition of YAML files for merged reports that have not been reviewed, streamlining the process of handling such reports.