### PR TITLE
Update workflow to include EAR-UPDATE label on updated reports

### DIFF
--- a/.github/workflows/6_ear_bot_merge.yml
+++ b/.github/workflows/6_ear_bot_merge.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   closed-pr:
-    if: contains(github.event.pull_request.labels.*.name, 'ERGA-BGE') || contains(github.event.pull_request.labels.*.name, 'ERGA-Pilot') || contains(github.event.pull_request.labels.*.name, 'ERGA-Community')
+    if: contains(github.event.pull_request.labels.*.name, 'ERGA-BGE') || contains(github.event.pull_request.labels.*.name, 'ERGA-Pilot') || contains(github.event.pull_request.labels.*.name, 'ERGA-Community') || contains(github.event.pull_request.labels.*.name, 'EAR-UPDATE')
     runs-on: ubuntu-latest
     steps:
       - name: Generate a token

--- a/ear_bot/ear_bot_reviewer.py
+++ b/ear_bot/ear_bot_reviewer.py
@@ -155,7 +155,7 @@ class EARBotReviewer:
             pr.create_issue_comment(
                 f"Hi @{researcher} this looks like an update of an approved EAR. I will flag the PR to call the attention of a supervisor to handle this :)"
             )
-            pr.add_to_labels("ERROR!")
+            pr.add_to_labels("EAR-UPDATE")
             raise Exception("Modified file.")
 
         if not pr.body:


### PR DESCRIPTION
This is an update for #54
Enhance the workflow and reviewer logic to incorporate the EAR-UPDATE label, allowing for better tracking of relevant pull requests.