### PR TITLE
Skip non-EAR PRs in find_reviewer and lock down workflow permissions

### DIFF
--- a/.github/workflows/1_ear_bot_pr.yml
+++ b/.github/workflows/1_ear_bot_pr.yml
@@ -10,6 +10,8 @@ concurrency:
   group: ear-bot-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
+permissions: {}
+
 jobs:
   add-label-and-find-supervisor:
     runs-on: ubuntu-latest

--- a/.github/workflows/2+4_ear_bot_comment.yml
+++ b/.github/workflows/2+4_ear_bot_comment.yml
@@ -8,6 +8,8 @@ concurrency:
   group: ear-bot-pr-${{ github.event.issue.number }}
   cancel-in-progress: false
 
+permissions: {}
+
 jobs:
   new-comment:
     if: github.actor != 'erga-ear-bot[bot]' && github.event.issue.pull_request && (contains(github.event.issue.labels.*.name, 'ERGA-BGE') || contains(github.event.issue.labels.*.name, 'ERGA-Pilot') || contains(github.event.issue.labels.*.name, 'ERGA-Community'))

--- a/.github/workflows/3_ear_bot_reviewer.yml
+++ b/.github/workflows/3_ear_bot_reviewer.yml
@@ -10,6 +10,8 @@ concurrency:
   group: ear-bot-scheduled
   cancel-in-progress: false
 
+permissions: {}
+
 jobs:
   find-reviewer:
     runs-on: ubuntu-latest

--- a/.github/workflows/5_ear_bot_approved.yml
+++ b/.github/workflows/5_ear_bot_approved.yml
@@ -8,6 +8,8 @@ concurrency:
   group: ear-bot-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
+permissions: {}
+
 jobs:
   approved-changes:
     if: github.event.review.state == 'approved' && (contains(github.event.pull_request.labels.*.name, 'ERGA-BGE') || contains(github.event.pull_request.labels.*.name, 'ERGA-Pilot') || contains(github.event.pull_request.labels.*.name, 'ERGA-Community'))

--- a/.github/workflows/5_ear_bot_approved_comment.yml
+++ b/.github/workflows/5_ear_bot_approved_comment.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ear-bot-approved-${{ github.event.workflow_run.id }}
   cancel-in-progress: false
 
+permissions:
+  actions: read
+
 jobs:
   approved-changes:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}

--- a/.github/workflows/6_ear_bot_merge.yml
+++ b/.github/workflows/6_ear_bot_merge.yml
@@ -8,6 +8,8 @@ concurrency:
   group: ear-bot-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
+permissions: {}
+
 jobs:
   closed-pr:
     if: contains(github.event.pull_request.labels.*.name, 'ERGA-BGE') || contains(github.event.pull_request.labels.*.name, 'ERGA-Pilot') || contains(github.event.pull_request.labels.*.name, 'ERGA-Community') || contains(github.event.pull_request.labels.*.name, 'EAR-UPDATE')

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 .DS_Store
+__pycache__/
+*.py[cod]
+.mypy_cache/
+.ruff_cache/
+.pytest_cache/
+.venv/
+venv/

--- a/ear_bot/ear_bot_reviewer.py
+++ b/ear_bot/ear_bot_reviewer.py
@@ -341,10 +341,11 @@ class EARBotReviewer:
             reject: If True, treats the current reviewer as having declined
                     (used when comment() receives a "No" reply).
 
-        Skips PRs that already have a pending review request, an accepted
-        review, no project label, or no assigned supervisor.  Calls
-        _check_pr_activity() on every PR regardless of skip conditions to
-        keep DELAYED/STALLED labels up to date.
+        Skips PRs without a project label entirely.  For the remaining EAR
+        PRs, calls _check_pr_activity() regardless of the other skip
+        conditions to keep DELAYED/STALLED labels up to date, then skips
+        those with a pending review request, an accepted review, or no
+        assigned supervisor.
 
         Customisation: the 100-working-hour deadline comes from _deadline();
         change the ``timedelta(hours=100)`` there to adjust the timeout window.
@@ -356,12 +357,11 @@ class EARBotReviewer:
         current_date = datetime.now(tz=cet)
 
         for pr in prs:
+            if not any(label.name in self.valid_projects for label in pr.get_labels()):
+                continue
             self._check_pr_activity(pr, current_date)
             if (
                 pr.get_review_requests()[0].totalCount > 0
-                or not any(
-                    label.name in self.valid_projects for label in pr.get_labels()
-                )
                 or pr.get_reviews().totalCount > 0
                 or not pr.assignees
             ):

--- a/ear_bot/requirements.txt
+++ b/ear_bot/requirements.txt
@@ -3,3 +3,4 @@ pytz
 slack_sdk
 pdfplumber
 pyyaml
+requests


### PR DESCRIPTION
`find_reviewer` called `_check_pr_activity` before checking the project label, so it ran against every open PR in the repo. The bot has been adding DELAYED and STALLED labels and posting weekly ping comments on unrelated PRs. See #401, where it has pinged `@dependabot[bot]` twice. The project label check now happens first. EAR PRs still get their activity check regardless of the other skip conditions, same as before.

Add a `permissions` block to all six workflows. The bot authenticates with `GITHUB_APP_TOKEN`, so the ambient `GITHUB_TOKEN` does not need anything. Set to `{}` everywhere except `5_ear_bot_approved_comment.yml`, which needs `actions: read` to list and download the artifact from the triggering run.

Add `requests` to `ear_bot/requirements.txt`. `rev/get_EAR_reviewer.py` imports it directly and it was only resolving because PyGithub happens to depend on it.

Add the usual Python caches to `.gitignore`, which was only `.DS_Store`.

Checked with a stale unlabelled PR and a stale labelled one. The unlabelled PR now gets no labels and no ping, and the labelled one still gets DELAYED and STALLED. Independent of #403, they touch different parts of the function.